### PR TITLE
input: add optional chase mouse look

### DIFF
--- a/apps/syphon_filter/launcher.cpp
+++ b/apps/syphon_filter/launcher.cpp
@@ -18,6 +18,7 @@
 #include <array>
 #include <cmath>
 #include <cstdint>
+#include <cwchar>
 #include <cwctype>
 #include <filesystem>
 #include <limits>
@@ -57,6 +58,9 @@ constexpr int change_binding_control_id = 2002;
 constexpr int clear_binding_control_id = 2003;
 constexpr int default_bindings_control_id = 2004;
 constexpr int close_bindings_control_id = 2005;
+constexpr int mouse_chase_look_control_id = 2006;
+constexpr int chase_yaw_sensitivity_control_id = 2007;
+constexpr int chase_pitch_sensitivity_control_id = 2008;
 constexpr int previous_dossier_control_id = 3001;
 constexpr int next_dossier_control_id = 3002;
 constexpr int close_dossier_control_id = 3003;
@@ -109,6 +113,9 @@ struct ControlsState {
   HWND list{};
   HWND change_button{};
   HWND status{};
+  HWND mouse_chase_look{};
+  HWND chase_yaw_sensitivity{};
+  HWND chase_pitch_sensitivity{};
   HFONT title_font{};
   HFONT heading_font{};
   HFONT ui_font{};
@@ -212,6 +219,45 @@ void writeProfileInteger(const std::filesystem::path &path,
       WritePrivateProfileStringW(section, key, text.c_str(), path.c_str()));
 }
 
+std::wstring sensitivityText(double value) {
+  auto text = std::to_wstring(value);
+  while (!text.empty() && text.back() == L'0') {
+    text.pop_back();
+  }
+  if (!text.empty() && text.back() == L'.') {
+    text.pop_back();
+  }
+  return text;
+}
+
+std::optional<double> sensitivityFromControl(HWND control) noexcept {
+  std::array<wchar_t, 64U> text{};
+  const auto copied = GetWindowTextW(control, text.data(),
+                                     static_cast<int>(text.size()));
+  if (copied <= 0 || static_cast<std::size_t>(copied) >= text.size()) {
+    return std::nullopt;
+  }
+  wchar_t *end{};
+  const auto value = std::wcstod(text.data(), &end);
+  while (end != nullptr && std::iswspace(*end) != 0) {
+    ++end;
+  }
+  if (end == text.data() || end == nullptr || *end != L'\0' ||
+      !std::isfinite(value) || value < minimum_chase_mouse_sensitivity ||
+      value > maximum_chase_mouse_sensitivity) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+void refreshChaseSensitivityControls(ControlsState &state) {
+  const auto yaw = sensitivityText(state.input->chase_mouse_yaw_sensitivity);
+  const auto pitch =
+      sensitivityText(state.input->chase_mouse_pitch_sensitivity);
+  SetWindowTextW(state.chase_yaw_sensitivity, yaw.c_str());
+  SetWindowTextW(state.chase_pitch_sensitivity, pitch.c_str());
+}
+
 std::filesystem::path loadGameImagePath() {
   const auto path = launcherSettingsPath(false);
   std::array<wchar_t, 32768U> buffer{};
@@ -282,6 +328,27 @@ void loadSettingsFile(GraphicsSettings &graphics, KeyboardMouseBindings &input,
       input[action] = loaded;
     }
   }
+  input.mouse_chase_look =
+      readProfileInteger(path, L"KeyboardMouse", L"MouseChaseLook",
+                         input.mouse_chase_look ? 1 : 0) != 0;
+  const auto chase_yaw = readProfileInteger(
+      path, L"KeyboardMouse", L"ChaseYawSensitivity",
+      static_cast<int>(std::lround(input.chase_mouse_yaw_sensitivity * 1000.0)));
+  const auto chase_pitch = readProfileInteger(
+      path, L"KeyboardMouse", L"ChasePitchSensitivity",
+      static_cast<int>(
+          std::lround(input.chase_mouse_pitch_sensitivity * 1000.0)));
+  const auto load_sensitivity = [](int scaled, double fallback) {
+    const auto value = static_cast<double>(scaled) / 1000.0;
+    return value >= minimum_chase_mouse_sensitivity &&
+                   value <= maximum_chase_mouse_sensitivity
+               ? value
+               : fallback;
+  };
+  input.chase_mouse_yaw_sensitivity = load_sensitivity(
+      chase_yaw, input.chase_mouse_yaw_sensitivity);
+  input.chase_mouse_pitch_sensitivity = load_sensitivity(
+      chase_pitch, input.chase_mouse_pitch_sensitivity);
 }
 
 void saveSettingsFile(const GraphicsSettings &graphics,
@@ -312,6 +379,15 @@ void saveSettingsFile(const GraphicsSettings &graphics,
     writeProfileInteger(path, L"KeyboardMouse", key.c_str(),
                         static_cast<int>(input[action]));
   }
+  writeProfileInteger(path, L"KeyboardMouse", L"MouseChaseLook",
+                      input.mouse_chase_look ? 1 : 0);
+  writeProfileInteger(
+      path, L"KeyboardMouse", L"ChaseYawSensitivity",
+      static_cast<int>(std::lround(input.chase_mouse_yaw_sensitivity * 1000.0)));
+  writeProfileInteger(
+      path, L"KeyboardMouse", L"ChasePitchSensitivity",
+      static_cast<int>(
+          std::lround(input.chase_mouse_pitch_sensitivity * 1000.0)));
   saveGameImagePath(cue_path);
 }
 
@@ -868,9 +944,24 @@ LRESULT CALLBACK controlsWindowProc(HWND window, UINT message, WPARAM w_param,
     state->status = createControl(window, L"STATIC",
                                   L"Select an action, then press Change.", 0,
                                   472, 332, 244, 62, 0, state->ui_font);
-    createControl(window, L"STATIC",
-                  L"Stealth: crouch + movement\nSide roll: roll + strafe", 0,
-                  472, 398, 244, 44, 0, state->ui_font);
+    state->mouse_chase_look = createControl(
+        window, L"BUTTON", L"Mouse look in chase mode",
+        WS_TABSTOP | BS_AUTOCHECKBOX, 472, 366, 244, 24,
+        mouse_chase_look_control_id, state->ui_font);
+    SendMessageW(state->mouse_chase_look, BM_SETCHECK,
+                 state->input->mouse_chase_look ? BST_CHECKED : BST_UNCHECKED,
+                 0);
+    createControl(window, L"STATIC", L"Horizontal", 0, 472, 394, 112, 20, 0,
+                  state->ui_font);
+    createControl(window, L"STATIC", L"Vertical", 0, 604, 394, 112, 20, 0,
+                  state->ui_font);
+    state->chase_yaw_sensitivity = createControl(
+        window, L"EDIT", L"", WS_TABSTOP | WS_BORDER | ES_AUTOHSCROLL, 472,
+        416, 112, 26, chase_yaw_sensitivity_control_id, state->ui_font);
+    state->chase_pitch_sensitivity = createControl(
+        window, L"EDIT", L"", WS_TABSTOP | WS_BORDER | ES_AUTOHSCROLL, 604,
+        416, 112, 26, chase_pitch_sensitivity_control_id, state->ui_font);
+    refreshChaseSensitivityControls(*state);
     createControl(window, L"BUTTON", L"APPLY", WS_TABSTOP | BS_OWNERDRAW, 472,
                   448, 244, 34, close_bindings_control_id, state->heading_font);
     refreshControlsList(*state);
@@ -939,12 +1030,34 @@ LRESULT CALLBACK controlsWindowProc(HWND window, UINT message, WPARAM w_param,
     }
     if (LOWORD(w_param) == default_bindings_control_id) {
       *state->input = defaultKeyboardMouseBindings();
+      SendMessageW(state->mouse_chase_look, BM_SETCHECK,
+                   state->input->mouse_chase_look ? BST_CHECKED
+                                                  : BST_UNCHECKED,
+                   0);
+      refreshChaseSensitivityControls(*state);
       state->capture.reset();
       refreshControlsList(*state);
       SetWindowTextW(state->status, L"Default controls restored.");
       return 0;
     }
+    if (LOWORD(w_param) == mouse_chase_look_control_id) {
+      state->input->mouse_chase_look =
+          SendMessageW(state->mouse_chase_look, BM_GETCHECK, 0, 0) ==
+          BST_CHECKED;
+      return 0;
+    }
     if (LOWORD(w_param) == close_bindings_control_id) {
+      const auto yaw =
+          sensitivityFromControl(state->chase_yaw_sensitivity);
+      const auto pitch =
+          sensitivityFromControl(state->chase_pitch_sensitivity);
+      if (!yaw.has_value() || !pitch.has_value()) {
+        SetWindowTextW(state->status,
+                       L"Sensitivity must be between 0.10 and 20.00.");
+        return 0;
+      }
+      state->input->chase_mouse_yaw_sensitivity = *yaw;
+      state->input->chase_mouse_pitch_sensitivity = *pitch;
       DestroyWindow(window);
       return 0;
     }

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -24,6 +24,12 @@ physical keyboard scancodes or mouse inputs and are saved in
 | Pause menu | Escape | Open or close pause |
 | Quick weapon 1..10 | 1..9, 0 | Equip the corresponding available quick slot |
 
-Mouse movement controls the sight only while Aim is held. Crouch plus movement
-is the stealth locomotion path; Roll plus Strafe selects a side roll. These are
-composed states, not separate bindable actions.
+Mouse movement controls the sight while Aim is held. The optional **Mouse look
+in chase mode** checkbox in Input Configuration also captures the mouse during
+normal gameplay: horizontal motion turns Gabe through the common retail
+actor/camera facing path, while vertical motion pitches the unlocked chase
+camera. Scripted and locked cameras retain ownership. Separate horizontal and
+vertical sensitivity values
+are available beside the checkbox and accept values from 0.10 to 20.00. Crouch
+plus movement is the stealth locomotion path; Roll plus Strafe selects a side
+roll. These are composed states, not separate bindable actions.

--- a/include/sf/game/chase_camera.hpp
+++ b/include/sf/game/chase_camera.hpp
@@ -63,6 +63,11 @@ headingDirection(std::int32_t heading) noexcept;
 [[nodiscard]] CameraRay
 cameraRayAtProjectionOffset(const CameraState &camera, double horizontal_offset,
                             double vertical_offset) noexcept;
+// Applies optional modern pitch to an authored chase view without moving its
+// eye or changing projection. Positive pitch looks upward in the game's
+// positive-Y-down world convention.
+[[nodiscard]] CameraState applyChaseCameraPitch(CameraState camera,
+                                                double pitch) noexcept;
 
 class ChaseCamera final {
 public:

--- a/include/sf/game/gameplay.hpp
+++ b/include/sf/game/gameplay.hpp
@@ -1169,6 +1169,7 @@ private:
   void updateScriptedObjects() noexcept;
   void updateCinematic();
   [[nodiscard]] bool legacyMissionAuthoritative() const noexcept;
+  void stageNativeChaseFreelook(const GameplayInput &input);
   void stageNativeFirstPersonAim(const GameplayInput &input);
   void stageLegacyHostState(const GameplayInput &input);
   [[nodiscard]] GameplayInput
@@ -1336,6 +1337,8 @@ private:
   LegacyRadioSkipSuppressionState legacy_radio_skip_suppression_{};
   double host_manual_aim_strafe_{};
   std::optional<std::int32_t> host_manual_aim_body_heading_;
+  bool host_free_look_active_{};
+  double host_free_look_pitch_{};
   std::optional<std::int32_t> pending_host_aim_heading_restore_;
   std::optional<LegacyCameraBridgeState> legacy_manual_aim_neutral_camera_;
   LegacyNativePoint legacy_manual_aim_neutral_player_root_;

--- a/include/sf/game/legacy_first_mission_runtime.hpp
+++ b/include/sf/game/legacy_first_mission_runtime.hpp
@@ -250,6 +250,7 @@ public:
   [[nodiscard]] bool
   applyHostAimLocomotion(const LegacyHostPlayerLocomotion &state) noexcept;
   void setHostAimRay(std::optional<LegacyHostAimRay> ray) noexcept;
+  void setHostChaseMouseYawInput(std::int32_t delta, bool enabled) noexcept;
   [[nodiscard]] bool restoreHostPlayerHeading(std::int32_t yaw) noexcept;
   [[nodiscard]] std::uint64_t hostAimRayPatchCount() const noexcept;
   [[nodiscard]] bool applyHostWeaponMenuInput(bool held,

--- a/include/sf/game/legacy_gameplay_vm.hpp
+++ b/include/sf/game/legacy_gameplay_vm.hpp
@@ -996,6 +996,7 @@ public:
       std::shared_ptr<LegacyVirtualCd> virtual_cd);
   void bindSyphonFilterUsaV11PlatformCalls();
   void bindSyphonFilterUsaV11BootstrapPlatformCalls();
+  void bindSyphonFilterUsaV11ChaseMouseYawHook();
   void bindSyphonFilterUsaV11HostAimRayHook(
       const LegacyHostAimRayProfile &profile =
           syphonFilterUsaV11HostAimRayProfile());
@@ -1076,6 +1077,13 @@ public:
       std::int32_t yaw,
       const LegacyNativeMissionBridgeProfile &profile =
           syphonFilterUsaV11NativeMissionBridgeProfile()) noexcept;
+  void setHostChaseMouseYawInput(std::int32_t delta, bool enabled) noexcept;
+  [[nodiscard]] std::uint64_t hostChaseMouseYawHookCount() const noexcept {
+    return host_chase_mouse_yaw_hook_count_;
+  }
+  [[nodiscard]] std::int32_t hostChaseMouseYawCommand() const noexcept {
+    return host_chase_mouse_yaw_command_;
+  }
   void setHostAimRay(std::optional<LegacyHostAimRay> ray) noexcept;
   [[nodiscard]] std::uint64_t hostAimRayPatchCount() const noexcept {
     return host_aim_ray_patch_count_;
@@ -1266,9 +1274,13 @@ private:
   LegacyGameplayBridgeReadStage last_bridge_read_stage_{
       LegacyGameplayBridgeReadStage::none};
   std::uint64_t host_aim_ray_patch_count_{};
+  std::int32_t host_chase_mouse_yaw_pending_{};
+  std::int32_t host_chase_mouse_yaw_command_{};
+  std::uint64_t host_chase_mouse_yaw_hook_count_{};
   std::uint64_t enemy_close_aim_patch_count_{};
   bool video_timing_baseline_initialized_{};
   bool audio_frame_tick_initialized_{};
+  bool host_chase_mouse_yaw_enabled_{};
 };
 
 } // namespace sf::game

--- a/include/sf/platform/player_input.hpp
+++ b/include/sf/platform/player_input.hpp
@@ -183,8 +183,20 @@ enum class KeyboardMouseAction : std::uint8_t {
 inline constexpr auto keyboard_mouse_action_count =
     static_cast<std::size_t>(KeyboardMouseAction::count);
 
+inline constexpr double default_chase_mouse_yaw_sensitivity = 3.75;
+inline constexpr double default_chase_mouse_pitch_sensitivity = 1.5;
+inline constexpr double minimum_chase_mouse_sensitivity = 0.1;
+inline constexpr double maximum_chase_mouse_sensitivity = 20.0;
+
 struct KeyboardMouseBindings {
   std::array<KeyboardMouseInput, keyboard_mouse_action_count> values{};
+  // Opt-in modern chase control. Disabled preserves the original RMB-only
+  // relative mouse capture and retail tank controls.
+  bool mouse_chase_look{};
+  double chase_mouse_yaw_sensitivity{
+      default_chase_mouse_yaw_sensitivity};
+  double chase_mouse_pitch_sensitivity{
+      default_chase_mouse_pitch_sensitivity};
 
   [[nodiscard]] KeyboardMouseInput
   operator[](KeyboardMouseAction action) const noexcept {

--- a/src/game/chase_camera.cpp
+++ b/src/game/chase_camera.cpp
@@ -77,6 +77,20 @@ CameraRay cameraRayAtProjectionOffset(const CameraState &camera,
   };
 }
 
+CameraState applyChaseCameraPitch(CameraState camera, double pitch) noexcept {
+  const auto clamped = std::clamp(pitch, -512.0, 512.0);
+  const auto horizontal_distance =
+      std::hypot(camera.target_x - camera.x, camera.target_z - camera.z);
+  if (!std::isfinite(horizontal_distance) || horizontal_distance <= 0.000001) {
+    return camera;
+  }
+  const auto radians =
+      clamped *
+      (2.0 * std::numbers::pi / static_cast<double>(heading_angle_units));
+  camera.target_y -= std::tan(radians) * horizontal_distance;
+  return camera;
+}
+
 ChaseCamera::ChaseCamera(ChaseCameraConfiguration configuration) noexcept
     : configuration_(configuration) {}
 

--- a/src/game/gameplay.cpp
+++ b/src/game/gameplay.cpp
@@ -1669,6 +1669,8 @@ void GameplaySession::reset() {
   legacy_radio_skip_suppression_ = {};
   host_manual_aim_strafe_ = 0.0;
   host_manual_aim_body_heading_.reset();
+  host_free_look_active_ = false;
+  host_free_look_pitch_ = 0.0;
   pending_host_aim_heading_restore_.reset();
   legacy_manual_aim_neutral_camera_.reset();
   legacy_manual_aim_neutral_player_root_ = {};
@@ -1920,6 +1922,8 @@ bool GameplaySession::restartCheckpoint() {
   legacy_radio_skip_suppression_ = {};
   host_manual_aim_strafe_ = 0.0;
   host_manual_aim_body_heading_.reset();
+  host_free_look_active_ = false;
+  host_free_look_pitch_ = 0.0;
   pending_host_aim_heading_restore_.reset();
   legacy_manual_aim_neutral_camera_.reset();
   legacy_manual_aim_neutral_player_root_ = {};
@@ -3924,6 +3928,39 @@ GameplayInput GameplaySession::admittedFirstPersonAimInput(
   return admitted;
 }
 
+void GameplaySession::stageNativeChaseFreelook(const GameplayInput &input) {
+  if (input.aim || !playerAlive() || !legacyMissionAuthoritative() ||
+      !legacy_first_mission_->openingFinished()) {
+    if (legacy_first_mission_ != nullptr) {
+      legacy_first_mission_->setHostChaseMouseYawInput(0, false);
+    }
+    if (input.aim) {
+      host_free_look_active_ = false;
+      host_free_look_pitch_ = 0.0;
+    }
+    return;
+  }
+  const auto *bridge = legacy_first_mission_->bridge();
+  if (bridge == nullptr || !bridge->player.resident ||
+      bridge->player.control_locked || bridge->camera.scripted ||
+      bridge->camera.locked) {
+    legacy_first_mission_->setHostChaseMouseYawInput(0, false);
+    host_free_look_active_ = false;
+    host_free_look_pitch_ = 0.0;
+    return;
+  }
+
+  host_free_look_active_ = true;
+  legacy_first_mission_->setHostChaseMouseYawInput(
+      static_cast<std::int32_t>(std::clamp(
+          std::llround(input.look_yaw),
+          static_cast<long long>(std::numeric_limits<std::int32_t>::min()),
+          static_cast<long long>(std::numeric_limits<std::int32_t>::max()))),
+      true);
+  host_free_look_pitch_ =
+      std::clamp(host_free_look_pitch_ + input.look_pitch, -512.0, 512.0);
+}
+
 void GameplaySession::stageNativeFirstPersonAim(const GameplayInput &input) {
   // Always consume the host release edge first. A retail camera/control lock
   // may appear on that same update; it must not leave the native controller
@@ -5915,6 +5952,7 @@ void GameplaySession::update(const GameplayInput &input) {
   }
 
   const auto guest_weapon_before_update = hud_.inventory().current();
+  stageNativeChaseFreelook(input);
   const auto admitted_input = admittedFirstPersonAimInput(input);
   stageNativeFirstPersonAim(admitted_input);
   stageLegacyHostState(admitted_input);
@@ -6391,7 +6429,7 @@ CameraState GameplaySession::camera() const noexcept {
       }
       return native;
     }
-    return CameraState{
+    auto native_chase = CameraState{
         static_cast<double>(camera.eye.x),
         static_cast<double>(camera.eye.y),
         static_cast<double>(camera.eye.z),
@@ -6400,6 +6438,12 @@ CameraState GameplaySession::camera() const noexcept {
         static_cast<double>(camera.target.z),
         camera.projectionForDisplayWidth(384),
     };
+    if (host_free_look_active_ && !bridge.player.control_locked &&
+        !camera.scripted && !camera.locked) {
+      native_chase =
+          applyChaseCameraPitch(native_chase, host_free_look_pitch_);
+    }
+    return native_chase;
   }
   if (mission_cinematic_phase_ == MissionCinematicPhase::intro) {
     if (legacy_first_mission_ != nullptr && legacy_first_mission_->ready() &&

--- a/src/game/legacy_first_mission_runtime.cpp
+++ b/src/game/legacy_first_mission_runtime.cpp
@@ -146,6 +146,7 @@ LegacyFirstMissionRuntime::LegacyFirstMissionRuntime(
     vm_ = std::make_unique<LegacyGameplayVm>(image.executable());
     vm_->bindSyphonFilterUsaV11BootstrapPlatformCalls();
     vm_->bindSyphonFilterUsaV11VirtualCdCalls(virtual_cd_);
+    vm_->bindSyphonFilterUsaV11ChaseMouseYawHook();
 
     if (mission.selection_index < 0) {
       markFault();
@@ -244,6 +245,13 @@ void LegacyFirstMissionRuntime::setHostAimRay(
     std::optional<LegacyHostAimRay> ray) noexcept {
   if (vm_) {
     vm_->setHostAimRay(std::move(ray));
+  }
+}
+
+void LegacyFirstMissionRuntime::setHostChaseMouseYawInput(
+    std::int32_t delta, bool enabled) noexcept {
+  if (vm_) {
+    vm_->setHostChaseMouseYawInput(delta, enabled);
   }
 }
 

--- a/src/game/legacy_gameplay_vm.cpp
+++ b/src/game/legacy_gameplay_vm.cpp
@@ -1657,6 +1657,46 @@ void LegacyGameplayVm::bindSyphonFilterUsaV11BootstrapPlatformCalls() {
   });
 }
 
+void LegacyGameplayVm::bindSyphonFilterUsaV11ChaseMouseYawHook() {
+  // Common actor-facing/camera boundary used by the accepted SF1 Redux mouse
+  // path. The processed controller is preserved in s2 at this instruction.
+  constexpr std::uint32_t boundary = 0x80037b08U;
+  constexpr std::uint32_t horizontal_offset = 0xccU;
+  constexpr std::uint32_t middle_offset = 0xd0U;
+  constexpr std::uint32_t vertical_offset = 0xd4U;
+  constexpr std::int32_t fixed_one = 4096;
+  bindHostCall(boundary, [this](LegacyHostCallContext &context) {
+    if (host_chase_mouse_yaw_enabled_) {
+      const auto command =
+          std::clamp(host_chase_mouse_yaw_pending_, -256, 256);
+      const auto controller = context.registerValue(18U);
+      if (command != 0 && controller != 0U &&
+          context.write32(controller + horizontal_offset,
+                          guestWord(command * fixed_one)) &&
+          context.write32(controller + middle_offset, 0U) &&
+          context.write32(controller + vertical_offset, 0U)) {
+        host_chase_mouse_yaw_command_ = command;
+        host_chase_mouse_yaw_pending_ = 0;
+        ++host_chase_mouse_yaw_hook_count_;
+      }
+    }
+    context.continueGuestInstruction();
+  });
+}
+
+void LegacyGameplayVm::setHostChaseMouseYawInput(std::int32_t delta,
+                                                  bool enabled) noexcept {
+  host_chase_mouse_yaw_enabled_ = enabled;
+  if (!enabled) {
+    host_chase_mouse_yaw_pending_ = 0;
+    host_chase_mouse_yaw_command_ = 0;
+    return;
+  }
+  host_chase_mouse_yaw_pending_ = static_cast<std::int32_t>(std::clamp(
+      static_cast<std::int64_t>(host_chase_mouse_yaw_pending_) + delta,
+      std::int64_t{-1024}, std::int64_t{1024}));
+}
+
 void LegacyGameplayVm::bindSyphonFilterUsaV11EnemyCloseAimHook(
     const LegacyEnemyCloseAimProfile &profile) {
   bindHostCall(profile.boundary, [this,
@@ -2119,6 +2159,10 @@ void LegacyGameplayVm::clearHostCalls() noexcept {
   attached_text_sources_.clear();
   ui_messages_.clear();
   host_aim_ray_patch_count_ = 0U;
+  host_chase_mouse_yaw_pending_ = 0;
+  host_chase_mouse_yaw_command_ = 0;
+  host_chase_mouse_yaw_hook_count_ = 0U;
+  host_chase_mouse_yaw_enabled_ = false;
   enemy_close_aim_patch_count_ = 0U;
   interrupt_callbacks_.fill(0U);
   machine_.setCdRomMedia(nullptr);
@@ -6383,6 +6427,11 @@ bool LegacyGameplayVm::restoreSnapshot(
   ui_messages_ = snapshot.ui_messages;
   pending_actor_drops_ = snapshot.pending_actor_drops;
   weapon_events_.clear();
+  // Host input is presentation-time state and must never replay across a
+  // checkpoint or restart snapshot.
+  host_chase_mouse_yaw_pending_ = 0;
+  host_chase_mouse_yaw_command_ = 0;
+  host_chase_mouse_yaw_enabled_ = false;
   return true;
 }
 

--- a/src/platform/psycross_scene_runtime.inc
+++ b/src/platform/psycross_scene_runtime.inc
@@ -127,12 +127,14 @@ SceneViewerResult PsyCrossSceneViewer::run(
   double presentation_delta_seconds = 0.0;
   game::GameplayInput latched_gameplay_input{};
   sf::platform::PlayerLookLatch latched_player_look;
+  sf::platform::PlayerLookLatch latched_chase_look;
   sf::platform::PlayerLookDisplayIntegrator display_player_look;
   sf::platform::PlayerAimFireLatch latched_aim_for_fire;
   sf::platform::PlayerLookSample presentation_look_correction{};
   const auto clear_latched_gameplay_input = [&] {
     latched_gameplay_input = {};
     latched_player_look.reset();
+    latched_chase_look.reset();
     display_player_look.reset();
     latched_aim_for_fire.reset();
     presentation_look_correction = {};
@@ -826,7 +828,8 @@ SceneViewerResult PsyCrossSceneViewer::run(
     const auto interact_pressed =
         input_settle_seconds <= 0.0 && interact_down && !interact_was_down;
     const auto manual_aim_down = bound_actions[KeyboardMouseAction::aim];
-    mouse_capture.set(!paused && manual_aim_down);
+    mouse_capture.set(!paused &&
+                      (manual_aim_down || input_.mouse_chase_look));
     int mouse_delta_x{};
     int mouse_delta_y{};
     SDL_GetRelativeMouseState(&mouse_delta_x, &mouse_delta_y);
@@ -1349,11 +1352,24 @@ SceneViewerResult PsyCrossSceneViewer::run(
       relative_look.mouse_look_yaw = first_person_input.mouse_look.yaw;
       relative_look.mouse_look_pitch = first_person_input.mouse_look.pitch;
       latched_player_look.latch(relative_look);
+      latched_chase_look.reset();
     } else if (!latched_aim_for_fire.pending()) {
       // If an aimed fire edge is pending, retain the look sample paired with
       // that edge instead of replacing it with post-RMB-release controller
       // state before the guest consumes the shot.
       latched_player_look.reset();
+      if (input_.mouse_chase_look) {
+        sf::platform::PlayerInput relative_look;
+        relative_look.mouse_look_yaw =
+            raw_player_input.pc.mouse_delta_x *
+            input_.chase_mouse_yaw_sensitivity;
+        relative_look.mouse_look_pitch =
+            -raw_player_input.pc.mouse_delta_y *
+            input_.chase_mouse_pitch_sensitivity;
+        latched_chase_look.latch(relative_look);
+      } else {
+        latched_chase_look.reset();
+      }
     }
     latch_gameplay_input(sampled_input);
     simulation_accumulator_seconds =
@@ -1375,9 +1391,27 @@ SceneViewerResult PsyCrossSceneViewer::run(
         consumed_look = nativeManualAimLook(relative);
         simulation_input.look_yaw += consumed_look.yaw;
         simulation_input.look_pitch -= consumed_look.pitch;
+      } else {
+        const auto relative = simulation_updates_this_frame == 0U
+                                  ? latched_chase_look.consumeForGuestTick()
+                                  : sf::platform::PlayerLookSample{};
+        // SF2/SF3 use both paths: retail turn keeps locomotion, animation and
+        // collision aligned, while the proportional guest-facing command
+        // removes the analog camera response ceiling. Mouse yaw must reach
+        // both in the same guest tick; neither path is a substitute for the
+        // other.
+        simulation_input.turn = std::clamp(
+            simulation_input.turn +
+                relative.yaw /
+                    static_cast<double>(
+                        game::PlayerController::turn_units_per_update),
+            -1.0, 1.0);
+        simulation_input.look_yaw += relative.yaw;
+        simulation_input.look_pitch += relative.pitch * 0.35;
       }
       latched_gameplay_input = {};
       latched_player_look.reset();
+      latched_chase_look.reset();
       display_player_look.reset();
       std::swap(previous_render_presentation, current_render_presentation);
       previous_weapon_switch_countdown = current_weapon_switch_countdown;

--- a/tests/player_input_tests.cpp
+++ b/tests/player_input_tests.cpp
@@ -187,6 +187,13 @@ void testKeyboardMouseBindingCatalog() {
   const auto defaults = sf::platform::defaultKeyboardMouseBindings();
   require(sf::platform::keyboard_mouse_action_count == 31U,
           "Keyboard/mouse action catalog is incomplete");
+  require(!defaults.mouse_chase_look,
+          "Optional chase mouse look unexpectedly changed existing controls");
+  require(defaults.chase_mouse_yaw_sensitivity ==
+                  sf::platform::default_chase_mouse_yaw_sensitivity &&
+              defaults.chase_mouse_pitch_sensitivity ==
+                  sf::platform::default_chase_mouse_pitch_sensitivity,
+          "Optional chase mouse sensitivity defaults changed unexpectedly");
   for (std::size_t index = 0U;
        index < sf::platform::keyboard_mouse_action_count; ++index) {
     const auto action = static_cast<KeyboardMouseAction>(index);

--- a/tests/r3000_runtime_tests.cpp
+++ b/tests/r3000_runtime_tests.cpp
@@ -1714,6 +1714,42 @@ void testLegacyGameplayVmBoundary() {
   require(vm.unbindHostCall(overlay_address),
           "Could not remove the pass-through host hook");
 
+  constexpr std::uint32_t chase_mouse_hook = 0x80037b08U;
+  constexpr std::uint32_t chase_mouse_wrapper = overlay_address + 0x100U;
+  constexpr std::array chase_mouse_wrapper_words{
+      encodeI(0x0fU, 0U, 18U, 0x8002U),
+      encodeI(0x0dU, 18U, 18U, 0x0100U),
+      encodeJ(0x02U, chase_mouse_hook),
+      0U,
+  };
+  constexpr std::array chase_mouse_hook_words{
+      encodeI(0x09U, 0U, 2U, 77U),
+      encodeR(31U, 0U, 0U, 0U, 0x08U),
+      0U,
+  };
+  require(vm.loadOverlay(chase_mouse_wrapper,
+                         instructionBytes(chase_mouse_wrapper_words)) &&
+              vm.loadOverlay(chase_mouse_hook,
+                             instructionBytes(chase_mouse_hook_words)),
+          "Legacy chase mouse hook overlays failed to load");
+  vm.bindSyphonFilterUsaV11ChaseMouseYawHook();
+  vm.setHostChaseMouseYawInput(12, true);
+  const auto first_chase_mouse = vm.invoke(chase_mouse_wrapper, {});
+  vm.setHostChaseMouseYawInput(48, true);
+  const auto second_chase_mouse = vm.invoke(chase_mouse_wrapper, {});
+  require(first_chase_mouse.completed() && second_chase_mouse.completed() &&
+              first_chase_mouse.return_value == 77U &&
+              second_chase_mouse.return_value == 77U &&
+              vm.hostChaseMouseYawHookCount() == 2U &&
+              vm.hostChaseMouseYawCommand() == 48,
+          "Chase mouse yaw did not preserve proportional guest commands");
+  vm.setHostChaseMouseYawInput(99, false);
+  const auto disabled_chase_mouse = vm.invoke(chase_mouse_wrapper, {});
+  require(disabled_chase_mouse.completed() &&
+              vm.hostChaseMouseYawHookCount() == 2U &&
+              vm.hostChaseMouseYawCommand() == 0,
+          "Disabled chase mouse yaw still injected a guest command");
+
   constexpr auto retail_aim_profile =
       sf::game::syphonFilterUsaV11HostAimRayProfile();
   static_assert(

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1582,6 +1582,21 @@ void testChaseCamera() {
               std::abs(behind_north.target_z - 300.0) < 0.0001,
           "Chase camera did not stay behind the player");
 
+  const auto look_up = sf::game::applyChaseCameraPitch(behind_north, 256.0);
+  const auto look_down =
+      sf::game::applyChaseCameraPitch(behind_north, -256.0);
+  const auto clamped_pitch =
+      sf::game::applyChaseCameraPitch(behind_north, 10000.0);
+  const auto maximum_pitch =
+      sf::game::applyChaseCameraPitch(behind_north, 512.0);
+  require(look_up.x == behind_north.x && look_up.y == behind_north.y &&
+              look_up.z == behind_north.z &&
+              look_up.target_y < behind_north.target_y &&
+              look_down.target_y > behind_north.target_y &&
+              std::abs(clamped_pitch.target_y - maximum_pitch.target_y) <
+                  epsilon,
+          "Optional chase pitch moved the eye or escaped its clamp");
+
   const auto project_player_y = [&](double world_y) {
     constexpr auto native_screen_center_y = 120.0;
     constexpr auto native_projection = 320.0;


### PR DESCRIPTION
## Summary

- add opt-in chase-mode mouse look requested in #96
- retain retail turn input for locomotion/animation/collision while feeding proportional yaw through SF1's common facing boundary
- add bounded vertical chase-camera pitch with scripted/locked camera ownership preserved
- expose independent horizontal/vertical sensitivity values in Input Configuration and persist them in launcher.ini
- leave existing RMB aim, keyboard controls, and controller behavior unchanged when disabled

## Validation

- interactive validation by @Alexbeav across standing and moving chase-camera turns
- headless USA v1.1 probe confirmed `0x80037B08` is live with the expected controller pointer
- 21/21 configured CTests pass in Release/PsyCross
- community test build: [Public Test 23 + Optional Chase Mouse Look](https://github.com/Alexbeav/SF-pc-port/releases/tag/v0.1.0-public-test.23-mouselook.1)

Closes #96