### PR TITLE
Add macOS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if(POLICY CMP0174)
     cmake_policy(SET CMP0174 NEW)
 endif()
 
-project(SyphonFilterPC VERSION 0.1.0 LANGUAGES CXX)
+project(SyphonFilterPC VERSION 0.1.0 LANGUAGES C CXX)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -207,9 +207,13 @@ if(SF_ENABLE_PSYCROSS)
     sf_set_project_warnings(sf_psycross_backend)
 
     add_executable(syphon_filter
-        apps/syphon_filter/launcher.cpp
         apps/syphon_filter/main.cpp
     )
+    if(WIN32)
+        target_sources(syphon_filter PRIVATE apps/syphon_filter/launcher.cpp)
+    else()
+        target_sources(syphon_filter PRIVATE apps/syphon_filter/launcher_posix.cpp)
+    endif()
     if(WIN32)
         set(SF_LAUNCHER_ICON_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/syphon_filter.ico")
         set(SF_LAUNCHER_ICON_SOURCE

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -27,6 +27,27 @@
         "VCPKG_TARGET_TRIPLET": "x64-windows",
         "SF_ENABLE_PSYCROSS": "ON"
       }
+    },
+    {
+      "name": "macos",
+      "displayName": "macOS / Clang / Ninja",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/macos",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_PREFIX_PATH": "/opt/homebrew;/opt/homebrew/opt/openal-soft;/usr/local;/usr/local/opt/openal-soft",
+        "SF_WARNINGS_AS_ERRORS": "OFF",
+        "SF_BUILD_TESTS": "ON"
+      }
+    },
+    {
+      "name": "macos-psycross",
+      "displayName": "macOS / Clang / Ninja / PsyCross",
+      "inherits": "macos",
+      "binaryDir": "${sourceDir}/build/macos-psycross",
+      "cacheVariables": {
+        "SF_ENABLE_PSYCROSS": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -58,6 +79,14 @@
       "configurePreset": "windows-psycross",
       "configuration": "Release",
       "targets": ["syphon_filter"]
+    },
+    {
+      "name": "macos-release",
+      "configurePreset": "macos"
+    },
+    {
+      "name": "macos-psycross-release",
+      "configurePreset": "macos-psycross"
     }
   ],
   "testPresets": [
@@ -77,6 +106,16 @@
       "name": "windows-psycross-release",
       "configurePreset": "windows-psycross",
       "configuration": "Release",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "macos-release",
+      "configurePreset": "macos",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "macos-psycross-release",
+      "configurePreset": "macos-psycross",
       "output": { "outputOnFailure": true }
     }
   ]

--- a/apps/syphon_filter/launcher_posix.cpp
+++ b/apps/syphon_filter/launcher_posix.cpp
@@ -1,0 +1,83 @@
+// Minimal non-Windows implementation of the launcher interface.
+//
+// The Windows build provides a full Win32 launcher GUI in launcher.cpp.
+// On macOS and Linux the game is configured through command-line options
+// (see --help output in main.cpp); the graphical launcher is not shown.
+
+#include "launcher.hpp"
+
+#include <cstdio>
+#include <filesystem>
+#include <system_error>
+
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#elif defined(__linux__)
+#include <array>
+#include <unistd.h>
+#endif
+
+namespace {
+
+std::filesystem::path executableDirectory() {
+#if defined(__APPLE__)
+  std::uint32_t size = 0;
+  _NSGetExecutablePath(nullptr, &size);
+  std::string buffer(size, '\0');
+  if (_NSGetExecutablePath(buffer.data(), &size) == 0) {
+    std::error_code error;
+    const auto canonical =
+        std::filesystem::weakly_canonical(buffer, error);
+    if (!error && !canonical.empty()) {
+      return canonical.parent_path();
+    }
+  }
+#elif defined(__linux__)
+  std::array<char, 4096> buffer{};
+  const auto length =
+      ::readlink("/proc/self/exe", buffer.data(), buffer.size() - 1);
+  if (length > 0) {
+    return std::filesystem::path{
+        std::string_view(buffer.data(), static_cast<std::size_t>(length))}
+        .parent_path();
+  }
+#endif
+  return std::filesystem::current_path();
+}
+
+} // namespace
+
+namespace sf::platform {
+
+void loadLauncherSettings(GraphicsSettings & /*graphics*/,
+                          KeyboardMouseBindings & /*input*/,
+                          game::GameLanguage & /*language*/) noexcept {
+  // No persisted launcher settings outside the Windows GUI launcher.
+}
+
+bool showGraphicsLauncher(GraphicsSettings & /*settings*/,
+                          KeyboardMouseBindings & /*input*/,
+                          game::GameLanguage & /*language*/,
+                          std::filesystem::path & /*cue_path*/) {
+  std::fprintf(stderr,
+               "The graphical launcher is not available on this platform.\n"
+               "Pass the game image directly, for example:\n"
+               "  syphon_filter --no-launcher \"Syphon Filter (USA) "
+               "(v1.1).cue\"\n");
+  return false;
+}
+
+bool retailCheatMarkerExists() noexcept {
+  std::error_code error;
+  const auto marker = executableDirectory() / "syphon_filter_cheats";
+  return std::filesystem::exists(marker, error) && !error;
+}
+
+void showLauncherError(std::string_view title,
+                       std::string_view message) noexcept {
+  std::fprintf(stderr, "%.*s: %.*s\n", static_cast<int>(title.size()),
+               title.data(), static_cast<int>(message.size()),
+               message.data());
+}
+
+} // namespace sf::platform

--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -1,0 +1,22 @@
+# Finds the FFmpeg libraries used by the STR decoder through pkg-config.
+# This module is used on non-Windows hosts (Homebrew, Linux distributions);
+# Windows builds keep using the vcpkg toolchain.
+#
+# Sets the variables consumed by the root CMakeLists.txt:
+#   FFMPEG_INCLUDE_DIRS, FFMPEG_LIBRARY_DIRS, FFMPEG_LIBRARIES
+
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET
+    libavcodec
+    libavformat
+    libavutil
+    libswresample
+    libswscale
+)
+
+# Prefer absolute library paths: sf_media is a static library, so its private
+# link directories do not propagate to the executables that finally link FFmpeg.
+if(FFMPEG_LINK_LIBRARIES)
+    set(FFMPEG_LIBRARIES ${FFMPEG_LINK_LIBRARIES})
+endif()

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -63,6 +63,37 @@ cmake --build --preset windows-core-release
 
 This stops at `sf_game` and avoids compiling the platform executable.
 
+## macOS build
+
+The full stack, including the playable PsyCross application, also builds on
+macOS (Apple Silicon and Intel). Dependencies come from Homebrew instead of
+vcpkg:
+
+```sh
+brew install cmake ninja sdl2 openal-soft ffmpeg
+```
+
+Configure, build and test with the checked-in presets:
+
+```sh
+cmake --preset macos-psycross
+cmake --build --preset macos-psycross-release
+ctest --preset macos-psycross-release
+```
+
+The executable is written to `build/macos-psycross/syphon_filter`. A core-only
+build is available as the `macos` preset.
+
+The Win32 launcher GUI is not available on macOS; launch the game from the
+command line instead:
+
+```sh
+./build/macos-psycross/syphon_filter --no-launcher 'Syphon Filter (USA) (v1.1).cue'
+```
+
+User data is stored under `~/.local/share/SyphonFilterPC` unless
+`XDG_DATA_HOME` is set.
+
 ## Full validation
 
 The full presets compile every enabled target and run the deterministic tests:

--- a/external/PsyCross/include/psx/libapi.h
+++ b/external/PsyCross/include/psx/libapi.h
@@ -46,6 +46,8 @@ extern int rename(char* unk00, char *);
 extern int cd(char* unk00);
 */
 	
+struct EXEC; // defined in psx/kernel.h; forward declaration keeps C prototypes consistent
+
 extern int LoadTest(char*  unk00, struct EXEC *);
 extern int Load(char * unk00, struct EXEC *);
 extern int Exec(struct EXEC * unk00, int, char **);

--- a/external/PsyCross/include/psx/libgpu.h
+++ b/external/PsyCross/include/psx/libgpu.h
@@ -4,6 +4,10 @@
 #include "types.h"
 #include "PsyX/common/pgxp_defs.h"
 
+#if !defined(__cplusplus)
+#include <assert.h> // static_assert macro for C11-C17 TUs (MSVC accepts it unconditionally)
+#endif
+
 extern	int (*GPU_printf)(const char *fmt, ...);
 
 #define WAIT_TIME	0x800000
@@ -329,7 +333,7 @@ typedef struct _RECT16 {
 
 #if USE_EXTENDED_PRIM_POINTERS
 
-#if defined(_M_X64) || defined(__amd64__)
+#if defined(_M_X64) || defined(__amd64__) || defined(_M_ARM64) || defined(__aarch64__) || defined(__LP64__)
 
 #define DECLARE_P_ADDR \
 		uintptr_t addr; \

--- a/external/PsyCross/src/psx/LIBCD.C
+++ b/external/PsyCross/src/psx/LIBCD.C
@@ -8,7 +8,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#if !defined(__APPLE__) // macOS keeps malloc() in stdlib.h
 #include <malloc.h>
+#endif
 
 #ifdef _WIN32
 #include <direct.h>

--- a/src/disc/cue_sheet.cpp
+++ b/src/disc/cue_sheet.cpp
@@ -55,7 +55,7 @@ CueSheet CueSheet::load(const std::filesystem::path& cue_path) {
 
     const std::regex file_pattern{R"(^\s*FILE\s+\"([^\"]+)\"\s+BINARY\s*$)", std::regex::icase};
     const std::regex track_pattern{R"(^\s*TRACK\s+([0-9]+)\s+([^\s]+)\s*$)", std::regex::icase};
-    const std::regex index_pattern{R"(^\s*INDEX\s+01\s+([0-9]+):([0-9]+):([0-9]+)\s*$)", std::regex::icase};
+    const std::regex index_pattern{R"(^\s*INDEX\s+0?1\s+([0-9]+):([0-9]+):([0-9]+)\s*$)", std::regex::icase};
 
     std::optional<std::filesystem::path> binary_path;
     std::optional<TrackMode> mode;

--- a/src/platform/psycross_host.cpp
+++ b/src/platform/psycross_host.cpp
@@ -347,11 +347,13 @@ int titleAnalogDirection(const PADRAW &pad) noexcept {
   return 0;
 }
 
-std::vector<u_long> packWords(std::span<const std::uint16_t> words) {
-  std::vector<u_long> packed((words.size() + 1U) / 2U);
+std::vector<std::uint32_t> packWords(std::span<const std::uint16_t> words) {
+  // LoadImage reads the buffer as dense u16 units; pack without the padding
+  // that LP64 hosts (8-byte u_long) would leave between the words.
+  std::vector<std::uint32_t> packed((words.size() + 1U) / 2U);
   for (std::size_t index = 0; index < words.size(); ++index) {
     const auto shift = static_cast<unsigned int>((index & 1U) * 16U);
-    packed[index / 2U] |= static_cast<u_long>(words[index]) << shift;
+    packed[index / 2U] |= static_cast<std::uint32_t>(words[index]) << shift;
   }
   return packed;
 }
@@ -375,7 +377,7 @@ RECT16 blockRect(const assets::TimBlock &block) {
 void uploadBlock(const assets::TimBlock &block) {
   auto rect = blockRect(block);
   auto packed = packWords(block.words);
-  LoadImage(&rect, packed.data());
+  LoadImage(&rect, reinterpret_cast<u_long *>(packed.data()));
 }
 
 int texturePageMode(assets::TimPixelMode mode) {

--- a/src/platform/psycross_retail_briefing.cpp
+++ b/src/platform/psycross_retail_briefing.cpp
@@ -110,12 +110,14 @@ void uploadTimBlock(const assets::TimBlock &block) {
   };
   RECT16 rect{checked(block.x), checked(block.y), checked(block.width_words),
               checked(block.height)};
-  std::vector<u_long> packed((block.words.size() + 1U) / 2U);
+  // Dense 32-bit packing: LoadImage reinterprets the buffer as u16 units,
+  // and u_long leaves zero gaps between them on LP64 hosts.
+  std::vector<std::uint32_t> packed((block.words.size() + 1U) / 2U);
   for (std::size_t index = 0U; index < block.words.size(); ++index) {
-    packed[index / 2U] |= static_cast<u_long>(block.words[index])
+    packed[index / 2U] |= static_cast<std::uint32_t>(block.words[index])
                           << ((index & 1U) * 16U);
   }
-  LoadImage(&rect, packed.data());
+  LoadImage(&rect, reinterpret_cast<u_long *>(packed.data()));
 }
 
 void drawSolidRect(int x, int y, int width, int height, Rgb color) {

--- a/src/platform/psycross_vram.cpp
+++ b/src/platform/psycross_vram.cpp
@@ -35,17 +35,21 @@ namespace {
          (std::to_integer<std::uint32_t>(bytes[offset + 3]) << 24U);
 }
 
-[[nodiscard]] std::vector<u_long>
+[[nodiscard]] std::vector<std::uint32_t>
 packVramWords(std::span<const std::byte> bytes) {
   if ((bytes.size() & 1U) != 0U) {
     throw core::Error{core::ErrorCode::invalid_format,
                       "VRAM payload has an odd byte count"};
   }
+  // LoadImage reinterprets the buffer as a dense u16 array, so the packed
+  // words must be gapless 32-bit units. Packing into u_long leaves the high
+  // half of every 8-byte element zero on LP64 hosts, striping the upload.
   const auto word_count = bytes.size() / 2U;
-  std::vector<u_long> result((word_count + 1U) / 2U);
+  std::vector<std::uint32_t> result((word_count + 1U) / 2U);
   for (std::size_t index = 0; index < word_count; ++index) {
     const auto value = readLe16(bytes, index * 2U);
-    result[index / 2U] |= static_cast<u_long>(value) << ((index & 1U) * 16U);
+    result[index / 2U] |= static_cast<std::uint32_t>(value)
+                          << ((index & 1U) * 16U);
   }
   return result;
 }
@@ -128,7 +132,7 @@ void uploadTexturePage(unsigned int page, std::span<const std::byte> bytes) {
   }
   auto rect = texturePageRect(page);
   auto packed = packVramWords(bytes);
-  LoadImage(&rect, packed.data());
+  LoadImage(&rect, reinterpret_cast<u_long *>(packed.data()));
 }
 
 void uploadTexturePageAt(unsigned int physical_page,
@@ -151,7 +155,7 @@ void uploadTexturePageAt(unsigned int physical_page,
   }
   auto rect = physicalTexturePageRect(physical_page);
   auto packed = packVramWords(bytes);
-  LoadImage(&rect, packed.data());
+  LoadImage(&rect, reinterpret_cast<u_long *>(packed.data()));
 }
 
 void readTexturePageAt(unsigned int physical_page,
@@ -265,7 +269,7 @@ void uploadClut(std::span<const std::byte> bytes) {
   RECT16 rect{static_cast<short>(mission_clut_resident_x),
               static_cast<short>(mission_clut_resident_y), 256, 32};
   auto packed = packVramWords(bytes);
-  LoadImage(&rect, packed.data());
+  LoadImage(&rect, reinterpret_cast<u_long *>(packed.data()));
 }
 
 int texturePageMode(assets::TimPixelMode mode) noexcept {

--- a/src/psx/spu.cpp
+++ b/src/psx/spu.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <bit>
+#include <cstring>
 #include <limits>
 
 namespace sf::psx {
@@ -206,7 +207,11 @@ Spu::Spu()
 }
 
 void Spu::reset() noexcept {
-  *state_ = {};
+  // Clear the state in place. `*state_ = {}` materialises the ~580 KiB fresh
+  // state as a stack temporary, which overflows the 512 KiB default stack of
+  // macOS worker threads (the mission briefing preloads gameplay on one).
+  std::memset(state_.get(), 0, sizeof(SpuState));
+  state_->cd_input_matrix = {0x80U, 0U, 0U, 0x80U};
   state_->noise_level = 1U;
   clearPcm();
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -2659,6 +2659,20 @@ void testCueSheet() {
   require(cue.dataTrack().sectorSize() == 2352, "CUE sector size mismatch");
   require(cue.dataTrack().userDataOffset() == 24, "CUE data offset mismatch");
   require(cue.dataTrack().index_lba == 150, "CUE index mismatch");
+
+  // Single-digit INDEX 1 (CloneCD-style sheets) must parse the same as 01.
+  const auto single_digit_cue_path = directory / "single digit.cue";
+  {
+    std::ofstream cue{single_digit_cue_path, std::ios::trunc};
+    cue << "FILE \"test image.bin\" BINARY\r\n"
+           "   TRACK 1 MODE2/2352\r\n"
+           "   INDEX 1 00:00:00\r\n";
+  }
+  const auto single_digit_cue = sf::disc::CueSheet::load(single_digit_cue_path);
+  require(single_digit_cue.dataTrack().sectorSize() == 2352,
+          "CUE single-digit track sector size mismatch");
+  require(single_digit_cue.dataTrack().index_lba == 0,
+          "CUE single-digit index mismatch");
   std::filesystem::remove_all(directory);
 }
 


### PR DESCRIPTION
## Summary

Makes the full stack (core libraries, tests and the playable PsyCross application) build and run on macOS with Homebrew dependencies, and fixes three runtime bugs found while verifying against the supported USA v1.1 disc image.

**Build and platform**

- Enable C language in `project()` for the PsyCross C sources (required by CMake 4)
- Select the launcher source per platform; add `launcher_posix.cpp` with a minimal CLI-driven implementation of the launcher interface (the Win32 GUI launcher stays Windows-only)
- Add pkg-config based `FindFFMPEG.cmake` for Homebrew/Linux hosts
- PsyCross clang/aarch64 fixes: forward-declare `struct EXEC`, guard `malloc.h` on Apple, include `assert.h` for `static_assert` in C translation units, extend the 64-bit `P_LEN` guard to aarch64/LP64
- Add `macos` and `macos-psycross` CMake presets and document the workflow in `docs/BUILDING.md`

**Runtime fixes**

- Accept single-digit `INDEX 1` in CUE sheets — CloneCD dumps were rejected with "Expected one indexed data track" (test added)
- Fix mission-start crash: `Spu::reset()` materialized the ~580 KiB `SpuState` as a stack temporary, overflowing the 512 KiB default stack of the macOS preload worker thread (`EXC_BAD_ACCESS` in `__chkstk_darwin`); the state is now cleared in place
- Fix striped textures on LP64 hosts: TIM upload packers combined u16 words into 8-byte `u_long` elements, so `LoadImage` (dense u16 reader) saw zero gaps between words and every texture uploaded with alternating black stripes; they now pack into dense `uint32_t`

## Test plan

- `cmake --preset macos-psycross && cmake --build --preset macos-psycross-release && ctest --preset macos-psycross-release` — 21/21 pass (Apple Silicon, clang 22, Homebrew SDL2/OpenAL Soft/FFmpeg)
- Manual run: mission 1 starts and renders correctly (menu and in-game textures verified on screen)
- Windows build unaffected: all changes outside `external/PsyCross` are platform-neutral or guarded; PsyCross fixes are no-ops under MSVC/LLP64
