### PR TITLE
input: confine mouse in borderless fullscreen

### DIFF
--- a/src/platform/psycross_window_mode.cpp
+++ b/src/platform/psycross_window_mode.cpp
@@ -18,6 +18,27 @@ constexpr int minimum_window_height = 240;
 PsyCrossWindowMode* active_window_mode{};
 int mouse_wheel_delta{};
 
+void setMouseGrab(bool grabbed) noexcept {
+    if (g_window == nullptr) {
+        return;
+    }
+#if SDL_VERSION_ATLEAST(2, 0, 16)
+    SDL_SetWindowMouseGrab(g_window, grabbed ? SDL_TRUE : SDL_FALSE);
+#else
+    SDL_SetWindowGrab(g_window, grabbed ? SDL_TRUE : SDL_FALSE);
+#endif
+}
+
+void syncFullscreenMouseGrab() noexcept {
+    if (g_window == nullptr) {
+        return;
+    }
+    const auto flags = SDL_GetWindowFlags(g_window);
+    const auto fullscreen = (flags & SDL_WINDOW_FULLSCREEN) != 0;
+    const auto focused = (flags & SDL_WINDOW_INPUT_FOCUS) != 0;
+    setMouseGrab(fullscreen && focused);
+}
+
 bool isShortcutKey(const SDL_KeyboardEvent& event) noexcept {
     if (event.keysym.scancode == SDL_SCANCODE_F11) {
         return true;
@@ -46,6 +67,8 @@ PsyCrossWindowMode::PsyCrossWindowMode(bool start_fullscreen) {
 
     if (start_fullscreen) {
         setFullscreen(true);
+    } else {
+        syncFullscreenMouseGrab();
     }
 }
 
@@ -54,6 +77,7 @@ PsyCrossWindowMode::~PsyCrossWindowMode() {
         return;
     }
 
+    setMouseGrab(false);
     SDL_EventFilter current_filter{};
     void* current_userdata{};
     SDL_GetEventFilter(&current_filter, &current_userdata);
@@ -145,9 +169,22 @@ void PsyCrossWindowMode::captureWindowedBounds() noexcept {
 
 void PsyCrossWindowMode::observeWindowEvent(const SDL_WindowEvent& event) noexcept {
     if (switching_ || g_window == nullptr ||
-        event.windowID != SDL_GetWindowID(g_window) || isFullscreen()) {
+        event.windowID != SDL_GetWindowID(g_window)) {
         return;
     }
+
+    if (event.event == SDL_WINDOWEVENT_FOCUS_LOST) {
+        setMouseGrab(false);
+        return;
+    }
+    if (event.event == SDL_WINDOWEVENT_FOCUS_GAINED) {
+        syncFullscreenMouseGrab();
+        return;
+    }
+    if (isFullscreen()) {
+        return;
+    }
+
     if (event.event == SDL_WINDOWEVENT_MAXIMIZED) {
         windowed_bounds_.maximized = true;
     } else if (event.event == SDL_WINDOWEVENT_RESTORED) {
@@ -179,6 +216,7 @@ void PsyCrossWindowMode::restoreWindowedBounds() noexcept {
 
 void PsyCrossWindowMode::setFullscreen(bool fullscreen) noexcept {
     if (g_window == nullptr || fullscreen == isFullscreen()) {
+        syncFullscreenMouseGrab();
         return;
     }
     if (fullscreen) {
@@ -196,6 +234,7 @@ void PsyCrossWindowMode::setFullscreen(bool fullscreen) noexcept {
         restoreWindowedBounds();
     }
     switching_ = false;
+    syncFullscreenMouseGrab();
     syncRendererSize();
     PsyX_Log_Info("Window mode: %s (%dx%d)\n",
                   fullscreen ? "borderless fullscreen" : "windowed",


### PR DESCRIPTION
## Summary

- confine the mouse cursor to the game window while borderless fullscreen is focused
- release the grab on focus loss so Alt+Tab continues to work normally
- restore the grab on focus gain and resync it when switching fullscreen/windowed modes
- use `SDL_SetWindowMouseGrab` on SDL 2.0.16+ with `SDL_SetWindowGrab` as a compatibility fallback

## Problem

On multi-monitor setups, the system cursor is hidden but can still move onto another desktop while the game is running in borderless fullscreen. A mouse click can then focus a window on the other monitor, making keyboard/mouse input appear to drop out of the game.

The issue was reproducible with a second display enabled and disappeared when that display was disabled.

## Reproduction

1. Run the game in borderless fullscreen with two displays enabled.
2. Play using keyboard and mouse.
3. Move the mouse far enough toward the second display.
4. Click a mouse button.
5. The hidden system cursor can be on the second desktop, causing another window to receive focus.

## Validation

- Syphon Filter USA / NTSC-U v1.1 (SCUS-94240)
- Mission 1: Georgia Street / Subway
- 3840x2160 internal resolution, original PS1 4:3 aspect ratio
- borderless fullscreen
- reproduced on a dual-monitor Windows setup
- confirmed the cursor can no longer leave the game window while borderless fullscreen is focused
- confirmed Alt+Tab releases the grab and returning to the game restores it
- Windows/PsyCross build completed successfully
- GPU: NVIDIA GeForce RTX 5060 Ti
- NVIDIA driver: 610.88